### PR TITLE
Use secrets from correct sources.

### DIFF
--- a/k8s/k8sfabricator.go
+++ b/k8s/k8sfabricator.go
@@ -744,7 +744,7 @@ func (k *K8Fabricator) GetAllPodsEnvsByServiceId(creds K8sClusterCredentials, sp
 			for _, env := range container.Env {
 				if env.Value == "" {
 					logger.Debug("Empty env value, searching env variable in secrets")
-					simpleContainer.Envs[env.Name] = findSecretValue(secrets, envNameToSecretKey(env.Name))
+					simpleContainer.Envs[env.Name] = findSecretValue(secrets, env.ValueFrom.SecretKeyRef.Name, envNameToSecretKey(env.Name))
 				} else {
 					simpleContainer.Envs[env.Name] = env.Value
 				}
@@ -762,15 +762,18 @@ func envNameToSecretKey(env_name string) string {
 	return strings.Replace(lower_case_string, "_", "-", -1)
 }
 
-func findSecretValue(secrets *api.SecretList, secret_key string) string {
-	for _, i := range secrets.Items {
-		for key, value := range i.Data {
-			if key == secret_key {
+func findSecretValue(secrets *api.SecretList, secretName string, secretKey string) string {
+	for _, secret := range secrets.Items {
+		if secret.Name != secretName {
+			continue
+		}
+		for key, value := range secret.Data {
+			if key == secretKey {
 				return string((value))
 			}
 		}
 	}
-	logger.Info("Secret key not found: ", secret_key)
+	logger.Info("Secret key not found: ", secretKey)
 	return ""
 }
 


### PR DESCRIPTION
Only use secret values from the secret requested by the deployment.
