### PR TITLE
Revert load balancer address parser.

### DIFF
--- a/app/tap/main.go
+++ b/app/tap/main.go
@@ -145,15 +145,6 @@ func initServices(cfApp *cfenv.App) {
 		logger.Fatalf(`Unknown connector type "%s"`, os.Getenv("CONNECTOR_TYPE"))
 	}
 
-	switch os.Getenv("KUBE_ADDRESS_PARSER") {
-	case "consul":
-		addressParser = ConsulAddressParser{}
-	case "service":
-		addressParser = ServiceAddressParser{}
-	default:
-		logger.Fatalf(`Unknown address parser "%s"`, os.Getenv("KUBE_ADDRESS_PARSER"))
-	}
-
 	brokerConfig.StateService = &state.StateMemoryService{}
 	brokerConfig.KubernetesApi = k8s.NewK8Fabricator()
 	brokerConfig.ConsulApi = &consul.ConsulConnector{}

--- a/manifest.yml
+++ b/manifest.yml
@@ -18,7 +18,6 @@ env:
   KUBE_REPO_URL: ""
   KUBE_REPO_MAIL: ""
   KUBE_SSL_ACTIVE: false
-  KUBE_ADDRESS_PARSER: consul
   WAIT_BEFORE_NEXT_PV_CHECK_SEC: 120
   WAIT_BEFORE_REMOVE_CLUSTER_SEC: 3600
   GOPACKAGENAME: github.com/trustedanalytics/kubernetes-broker


### PR DESCRIPTION
Since ELBs are capped, the load balancer address parser doesn't have much practical use. This patch reverts to always parsing addresses using consul.
