### PR TITLE
[WIP] Install AWS Plugin for ES 2.3

### DIFF
--- a/custom_images/docker-elasticsearch-kubernetes-auth-23/Dockerfile
+++ b/custom_images/docker-elasticsearch-kubernetes-auth-23/Dockerfile
@@ -5,6 +5,9 @@ MAINTAINER devops@gsa.gov
 # Install elasticfence plugin
 RUN /elasticsearch/bin/plugin install https://raw.githubusercontent.com/elasticfence/elasticsearch-http-user-auth/2.3.5/jar/elasticfence-2.3.5-SNAPSHOT.zip
 
+# Install AWS Cloud plugin
+RUN /elasticsearch/bin/plugin install https://download.elastic.co/elasticsearch/release/org/elasticsearch/plugin/cloud-aws/2.3.5/cloud-aws-2.3.5.zip
+
 # Add elasticfence settings to config file
 ADD elasticfence.yml /elasticsearch/config/elasticfence.yml
 RUN cat /elasticsearch/config/elasticfence.yml >> /elasticsearch/config/elasticsearch.yml


### PR DESCRIPTION
This patch installs the aws plugin to ES 2.3.
The exact url for this was retreived by first running:

```sh
/elasticsearch/bin/plugin install cloud-aws
```

Which came from this [doc](https://www.elastic.co/guide/en/elasticsearch/plugins/2.3/cloud-aws.html)

In the output, it shows the url for the zip file for the aws plugin

Information for documenting this in the cg-site for [ES 2.3](https://cloud.gov/docs/services/elasticsearch23/) should mention the [ES AWS Snapshot & Restore documentation](https://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-snapshots.html)

# Note: After this patch is accepted, a manual push to the Docker Hub will need to happen.