### PR TITLE
[WIP] Add 12x plan for parity with legacy broker.

### DIFF
--- a/catalogData/elasticsearch24/12x/credentials-mappings.json
+++ b/catalogData/elasticsearch24/12x/credentials-mappings.json
@@ -1,0 +1,11 @@
+{
+  "hostname": "$hostname",
+  "username": "root",
+  "password": "$env_ES_PASSWORD",
+  "uri": "http://root:$env_ES_PASSWORD@$hostname:$port_9200",
+  "port": "$port_9200",
+  "ports": {
+    "9200/tcp": "$port_9200",
+    "9300/tcp": "$port_9300"
+  }
+}

--- a/catalogData/elasticsearch24/12x/k8s/deployment.json
+++ b/catalogData/elasticsearch24/12x/k8s/deployment.json
@@ -1,0 +1,126 @@
+{
+  "kind": "Deployment",
+  "apiVersion": "extensions/v1beta1",
+  "metadata": {
+    "name": "$idx_and_short_serviceid",
+    "labels": {
+      "org": "$org",
+      "space": "$space",
+      "catalog_service_id": "$catalog_service_id",
+      "catalog_plan_id": "$catalog_plan_id",
+      "service_id": "$service_id",
+      "idx_and_short_serviceid": "$idx_and_short_serviceid",
+      "managed_by": "TAP"
+    }
+  },
+  "spec": {
+    "replicas": 1,
+    "selector": {
+      "matchLabels" : {
+        "service_id": "$service_id",
+        "idx_and_short_serviceid": "$idx_and_short_serviceid"
+      }
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "service_id": "$service_id",
+          "idx_and_short_serviceid": "$idx_and_short_serviceid",
+          "managed_by": "TAP"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "k-elasticsearch24-persistent",
+            "image": "18fgsa/docker-elasticsearch-kubernetes-auth:2.4.1",
+            "resources": {
+              "limits": {
+                "memory": "13824M",
+                "cpu": 12
+              }
+            },
+            "securityContext": {
+              "privileged": true,
+              "add": [
+                "IPC_LOCK"
+              ]
+            },
+            "livenessProbe": {
+              "exec": {
+                "command": [ "/bin/sh", "-c", "/usr/bin/wget http://localhost:9200/_cluster/health?pretty -q -O - | /bin/grep cluster_name" ]
+              },
+              "initialDelaySeconds": 60,
+              "timeoutSeconds": 15,
+              "periodSeconds": 60,
+              "successThreshold": 1,
+              "failureThreshold": 4
+
+            },
+            "ports": [
+              {
+                "containerPort": 9200,
+                "protocol": "TCP"
+              },
+              {
+                "containerPort": 9300,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "NETWORK_HOST",
+                "value": "0.0.0.0"
+              },
+              {
+                "name": "ES_HEAP_SIZE",
+                "value": "6912m"
+              },
+              {
+                "name": "KUBERNETES_CERTS_CA_FILE",
+                "value": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+              },
+              {
+                "name": "CLUSTER_NAME",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "$short_serviceid-es-secret-keyfile",
+                    "key": "cluster-name"
+                  }
+                }
+              },
+              {
+                "name": "ES_PASSWORD",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "$short_serviceid-es-secret-keyfile",
+                    "key": "password"
+                  }
+                }
+              },
+              { "name": "NAMESPACE", "valueFrom": { "fieldRef": { "apiVersion": "v1", "fieldPath": "metadata.namespace" } } },
+              { "name": "MANAGED_BY", "value":"TAP" }
+            ],
+            "volumeMounts": [
+              {
+                "name": "elasticsearch-persistent-storage",
+                "mountPath": "/data"
+              }
+            ],
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "volumes": [
+          {
+            "name": "elasticsearch-persistent-storage",
+            "persistentVolumeClaim": {
+              "claimName": "$idx_and_short_serviceid"
+            }
+          }
+        ],
+        "restartPolicy": "Always",
+        "dnsPolicy": "ClusterFirst"
+      }
+    }
+  }
+}

--- a/catalogData/elasticsearch24/12x/k8s/persistentvolumeclaim.json
+++ b/catalogData/elasticsearch24/12x/k8s/persistentvolumeclaim.json
@@ -1,0 +1,29 @@
+{
+  "kind": "PersistentVolumeClaim",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "$idx_and_short_serviceid",
+    "labels": {
+      "org": "$org",
+      "space": "$space",
+      "catalog_service_id": "$catalog_service_id",
+      "catalog_plan_id": "$catalog_plan_id",
+      "service_id": "$service_id",
+      "idx_and_short_serviceid": "$idx_and_short_serviceid",
+      "managed_by": "TAP"
+    },
+    "annotations": {
+      "volume.beta.kubernetes.io/storage-class": "$storage_class"
+    }
+  },
+  "spec": {
+    "accessModes": [
+      "ReadWriteOnce"
+    ],
+    "resources": {
+      "requests": {
+        "storage": "20Gi"
+      }
+    }
+  }
+}

--- a/catalogData/elasticsearch24/12x/k8s/service.json
+++ b/catalogData/elasticsearch24/12x/k8s/service.json
@@ -1,0 +1,34 @@
+{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "$idx_and_short_serviceid",
+    "labels": {
+      "org": "$org",
+      "space": "$space",
+      "catalog_service_id": "$catalog_service_id",
+      "catalog_plan_id": "$catalog_plan_id",
+      "service_id": "$service_id",
+      "idx_and_short_serviceid": "$idx_and_short_serviceid",
+      "managed_by": "TAP"
+    }
+  },
+  "spec": {
+    "type": "NodePort",
+    "selector": {
+      "service_id": "$service_id"
+    },
+    "ports": [
+      {
+        "name": "rest",
+        "protocol": "TCP",
+        "port": 9200
+      },
+      {
+        "name": "transport",
+        "protocol": "TCP",
+        "port": 9300
+      }
+    ]
+  }
+}

--- a/catalogData/elasticsearch24/12x/plan.json
+++ b/catalogData/elasticsearch24/12x/plan.json
@@ -1,0 +1,6 @@
+{
+  "id": "ee0611f9-322a-4869-83f3-dac75d1fc7c1",
+  "name": "12x",
+  "description": "Elasticsearch instance with 12GB of RAM and 12 slices of CPU",
+  "free": true
+}


### PR DESCRIPTION
As @kynetiv pointed out, the 6x plan on the legacy broker allocated 6gb of heap, since heap and total memory were set to the same value. Which means that the 6x plan here has half the heap of the 6x legacy plan. This patch adds a 12x plan with 6gb of heap, which should correspond better to the legacy 6x plan. I also bumped the persistent disk allocation to 20gb.

I'm wondering if we'll want more and/or bigger boxes in the cluster to support this plan--I'll look into this, and hopefully get an opinion from @cnelson too. Then we'll spin up an instance for college scorecard and see if performance is adequate.