### PR TITLE
"Plan ids must be unique within a service."

### DIFF
--- a/catalogData/elasticsearch24/12x/plan.json
+++ b/catalogData/elasticsearch24/12x/plan.json
@@ -1,5 +1,5 @@
 {
-  "id": "ee0611f9-322a-4869-83f3-dac75d1fc7c1",
+  "id": "6d6d7c21-45b8-4b80-9b54-2dac3066759e",
   "name": "12x",
   "description": "Elasticsearch instance with 12GB of RAM and 12 slices of CPU",
   "free": true


### PR DESCRIPTION
Plan ids must be unique within a service. Service elasticsearch24 already has a plan with id 'ee0611f9-322a-4869-83f3-dac75d1fc7c1'

