### PR TITLE
cpu limits we can actually schedule

### DIFF
--- a/catalogData/elasticsearch24/12x/k8s/deployment.json
+++ b/catalogData/elasticsearch24/12x/k8s/deployment.json
@@ -37,7 +37,7 @@
             "resources": {
               "limits": {
                 "memory": "13824M",
-                "cpu": 12
+                "cpu": 2
               }
             },
             "securityContext": {

--- a/catalogData/elasticsearch24/12x/plan.json
+++ b/catalogData/elasticsearch24/12x/plan.json
@@ -1,6 +1,6 @@
 {
   "id": "6d6d7c21-45b8-4b80-9b54-2dac3066759e",
   "name": "12x",
-  "description": "Elasticsearch instance with 12GB of RAM and 12 slices of CPU",
+  "description": "Elasticsearch instance with 12GB of RAM and 2 AWS vCPUs",
   "free": true
 }

--- a/catalogData/elasticsearch24/1x/plan.json
+++ b/catalogData/elasticsearch24/1x/plan.json
@@ -1,6 +1,6 @@
 {
   "id": "fb492bce-d456-4227-9070-d67a50b8f6df",
   "name": "1x",
-  "description": "Elasticsearch instance with 1GB of RAM and 1 slices of CPU",
+  "description": "Elasticsearch instance with 1GB of RAM and 1 AWS vCPU",
   "free": true
 }

--- a/catalogData/elasticsearch24/3x/k8s/deployment.json
+++ b/catalogData/elasticsearch24/3x/k8s/deployment.json
@@ -37,7 +37,7 @@
             "resources": {
               "limits": {
                 "memory": "3584M",
-                "cpu": 3
+                "cpu": 1
               }
             },
             "securityContext": {

--- a/catalogData/elasticsearch24/3x/plan.json
+++ b/catalogData/elasticsearch24/3x/plan.json
@@ -1,6 +1,6 @@
 {
   "id": "ef3749e2-1470-4d9e-97f8-1e324f570705",
   "name": "3x",
-  "description": "Elasticsearch instance with 3GB of RAM and 3 slices of CPU",
+  "description": "Elasticsearch instance with 3GB of RAM and 1 AWS vCPU",
   "free": true
 }

--- a/catalogData/elasticsearch24/6x/k8s/deployment.json
+++ b/catalogData/elasticsearch24/6x/k8s/deployment.json
@@ -37,7 +37,7 @@
             "resources": {
               "limits": {
                 "memory": "6912M",
-                "cpu": 6
+                "cpu": 1
               }
             },
             "securityContext": {

--- a/catalogData/elasticsearch24/6x/plan.json
+++ b/catalogData/elasticsearch24/6x/plan.json
@@ -1,6 +1,6 @@
 {
   "id": "ee0611f9-322a-4869-83f3-dac75d1fc7c1",
   "name": "6x",
-  "description": "Elasticsearch instance with 6GB of RAM and 6 slices of CPU",
+  "description": "Elasticsearch instance with 6GB of RAM and 1 AWS vCPU",
   "free": true
 }


### PR DESCRIPTION
Unlike the docker broker in east which uses cpu shares as relative weights, k8s cpu limits [are equal to vCPUs when running on AWS](https://kubernetes.io/docs/user-guide/compute-resources/#meaning-of-cpu).  Since we dropped our vCPU count on minions to 4 in https://github.com/18F/cg-deploy-kubernetes/pull/63 / https://github.com/18F/kubernetes-broker/pull/39 the 6x and 12x jobs cannot be scheduled.

I think we'll want to reduce these to fractions  when we do https://github.com/18F/cg-atlas/issues/155 / https://github.com/18F/kubernetes-broker/issues/24 but this at least makes the jobs able to run for now

cc: @brittag @msecret as this also changes the user-facing descriptions you recently updated.