### PR TITLE
Ignore spurious warnings from aws-cloud plugin.

### DIFF
--- a/custom_images/docker-elasticsearch-kubernetes-auth-23/Dockerfile
+++ b/custom_images/docker-elasticsearch-kubernetes-auth-23/Dockerfile
@@ -7,6 +7,7 @@ RUN /elasticsearch/bin/plugin install https://raw.githubusercontent.com/elasticf
 
 # Install AWS Cloud plugin
 RUN /elasticsearch/bin/plugin install https://download.elastic.co/elasticsearch/release/org/elasticsearch/plugin/cloud-aws/2.3.5/cloud-aws-2.3.5.zip
+ADD logging.aws.yml /elasticsearch/config/logging.aws.yml
 
 # Add elasticfence settings to config file
 ADD elasticfence.yml /elasticsearch/config/elasticfence.yml

--- a/custom_images/docker-elasticsearch-kubernetes-auth-23/logging.aws.yml
+++ b/custom_images/docker-elasticsearch-kubernetes-auth-23/logging.aws.yml
@@ -1,0 +1,4 @@
+# Ignore spurious warnings from aws-cloud plugin
+# https://github.com/elastic/elasticsearch/issues/14013
+com.amazonaws.jmx.SdkMBeanRegistrySupport: ERROR
+com.amazonaws.metrics.AwsSdkMetrics: ERROR

--- a/custom_images/docker-elasticsearch-kubernetes-auth-24/Dockerfile
+++ b/custom_images/docker-elasticsearch-kubernetes-auth-24/Dockerfile
@@ -14,6 +14,7 @@ RUN /elasticsearch/bin/plugin install https://raw.githubusercontent.com/elasticf
 
 # Install AWS Cloud plugin
 RUN /elasticsearch/bin/plugin install https://download.elastic.co/elasticsearch/release/org/elasticsearch/plugin/cloud-aws/2.4.1/cloud-aws-2.4.1.zip
+ADD logging.aws.yml /elasticsearch/config/logging.aws.yml
 
 # Add elasticfence settings to config file
 ADD elasticfence.yml /elasticsearch/config/elasticfence.yml

--- a/custom_images/docker-elasticsearch-kubernetes-auth-24/logging.aws.yml
+++ b/custom_images/docker-elasticsearch-kubernetes-auth-24/logging.aws.yml
@@ -1,0 +1,4 @@
+# Ignore spurious warnings from aws-cloud plugin
+# https://github.com/elastic/elasticsearch/issues/14013
+com.amazonaws.jmx.SdkMBeanRegistrySupport: ERROR
+com.amazonaws.metrics.AwsSdkMetrics: ERROR


### PR DESCRIPTION
Encountered this while debugging an elastic issue reported by @kynetiv. I don't think this is the root of the problem, but it should help clear up spurious warnings and make further debugging easier.