### PR TITLE
Redis health check

### DIFF
--- a/catalogData/redis28/standard/k8s/deployment.json
+++ b/catalogData/redis28/standard/k8s/deployment.json
@@ -60,6 +60,16 @@
                 }
               }
             ],
+            "livenessProbe": {
+              "exec": {
+                "command": [
+                  "redis-cli",
+                  "ping"
+                ]
+              },
+              "initialDelaySeconds": 30,
+              "timeoutSeconds": 5
+            },
             "volumeMounts": [
               {
                 "name": "redis-persistent-storage",


### PR DESCRIPTION
Shamelessly lifted from
https://github.com/kubernetes/charts/blame/master/stable/redis/templates/deployment.yaml.

Will verify and revise once I'm home and back on the work vpn.