### PR TITLE
Set elastic resource requests to heap size.

### DIFF
--- a/catalogData/elasticsearch23/1x/k8s/deployment.json
+++ b/catalogData/elasticsearch23/1x/k8s/deployment.json
@@ -35,6 +35,10 @@
             "name": "k-elasticsearch23-persistent",
             "image": "18fgsa/docker-elasticsearch-kubernetes-auth:2.3.5",
             "resources": {
+              "requests": {
+                "memory": "768M",
+                "cpu": "0"
+              },
               "limits": {
                 "memory": "1536M",
                 "cpu": 1

--- a/catalogData/elasticsearch23/3x/k8s/deployment.json
+++ b/catalogData/elasticsearch23/3x/k8s/deployment.json
@@ -35,6 +35,10 @@
             "name": "k-elasticsearch23-persistent",
             "image": "18fgsa/docker-elasticsearch-kubernetes-auth:2.3.5",
             "resources": {
+              "requests": {
+                "memory": "1792M",
+                "cpu": "0"
+              },
               "limits": {
                 "memory": "3584M",
                 "cpu": 3

--- a/catalogData/elasticsearch23/6x/k8s/deployment.json
+++ b/catalogData/elasticsearch23/6x/k8s/deployment.json
@@ -35,6 +35,10 @@
             "name": "k-elasticsearch23-persistent",
             "image": "18fgsa/docker-elasticsearch-kubernetes-auth:2.3.5",
             "resources": {
+              "requests": {
+                "memory": "3456M",
+                "cpu": "0"
+              },
               "limits": {
                 "memory": "6912M",
                 "cpu": 6

--- a/catalogData/elasticsearch24/12x/k8s/deployment.json
+++ b/catalogData/elasticsearch24/12x/k8s/deployment.json
@@ -36,7 +36,7 @@
             "image": "18fgsa/docker-elasticsearch-kubernetes-auth:2.4.1",
             "resources": {
               "requests": {
-                "memory": "0",
+                "memory": "6912M",
                 "cpu": "0"
               },
               "limits": {

--- a/catalogData/elasticsearch24/1x/k8s/deployment.json
+++ b/catalogData/elasticsearch24/1x/k8s/deployment.json
@@ -35,6 +35,10 @@
             "name": "k-elasticsearch24-persistent",
             "image": "18fgsa/docker-elasticsearch-kubernetes-auth:2.4.1",
             "resources": {
+              "requests": {
+                "memory": "768M",
+                "cpu": "0"
+              },
               "limits": {
                 "memory": "1536M",
                 "cpu": 1

--- a/catalogData/elasticsearch24/3x/k8s/deployment.json
+++ b/catalogData/elasticsearch24/3x/k8s/deployment.json
@@ -36,7 +36,7 @@
             "image": "18fgsa/docker-elasticsearch-kubernetes-auth:2.4.1",
             "resources": {
               "requests": {
-                "memory": "0",
+                "memory": "1792M",
                 "cpu": "0"
               },
               "limits": {

--- a/catalogData/elasticsearch24/6x/k8s/deployment.json
+++ b/catalogData/elasticsearch24/6x/k8s/deployment.json
@@ -36,7 +36,7 @@
             "image": "18fgsa/docker-elasticsearch-kubernetes-auth:2.4.1",
             "resources": {
               "requests": {
-                "memory": "0",
+                "memory": "3456M",
                 "cpu": "0"
               },
               "limits": {


### PR DESCRIPTION
So that we stop scheduling elastic instances to hosts that can't handle their minimum memory requirements.

I'll apply this change manually to existing instances.