### PR TITLE
Wrap redis check in timeout

### DIFF
--- a/catalogData/redis28/standard/k8s/deployment.json
+++ b/catalogData/redis28/standard/k8s/deployment.json
@@ -63,6 +63,8 @@
             "livenessProbe": {
               "exec": {
                 "command": [
+                  "timeout",
+                  "1",
                   "redis-cli",
                   "ping"
                 ]


### PR DESCRIPTION
When attempting to accept https://favro.com/card/1e11108a2da81e3bd7153a7a/18F-5060; I noticed  that if the redis server is locked up (I simulated by sending a STOP signal to the process) that the redis-cli healthcheck will block forever and k8s won't ever get a return code to validate against.

This wraps the redis-cli call with timeout(1) to ensure it fails if redis doesn't respond within 1000ms


