### PR TITLE
wrap wget healthchecks in busybox's timeout.

### DIFF
--- a/catalogData/elasticsearch24/12x/k8s/deployment.json
+++ b/catalogData/elasticsearch24/12x/k8s/deployment.json
@@ -52,7 +52,7 @@
             },
             "livenessProbe": {
               "exec": {
-                "command": [ "/bin/sh", "-c", "/usr/bin/wget http://localhost:9200/_cluster/health?pretty -q -O - | /bin/grep cluster_name" ]
+                "command": [ "/bin/sh", "-c", "timeout -t 5 /usr/bin/wget http://localhost:9200/_cluster/health?pretty -q -O - | /bin/grep cluster_name" ]
               },
               "initialDelaySeconds": 60,
               "timeoutSeconds": 15,

--- a/catalogData/elasticsearch24/1x/k8s/deployment.json
+++ b/catalogData/elasticsearch24/1x/k8s/deployment.json
@@ -52,7 +52,7 @@
             },
             "livenessProbe": {
               "exec": {
-                "command": [ "/bin/sh", "-c", "/usr/bin/wget http://localhost:9200/_cluster/health?pretty -q -O - | /bin/grep cluster_name" ]
+                "command": [ "/bin/sh", "-c", "timeout -t 5 /usr/bin/wget http://localhost:9200/_cluster/health?pretty -q -O - | /bin/grep cluster_name" ]
               },
               "initialDelaySeconds": 60,
               "timeoutSeconds": 15,

--- a/catalogData/elasticsearch24/3x/k8s/deployment.json
+++ b/catalogData/elasticsearch24/3x/k8s/deployment.json
@@ -52,7 +52,7 @@
             },
             "livenessProbe": {
               "exec": {
-                "command": [ "/bin/sh", "-c", "/usr/bin/wget http://localhost:9200/_cluster/health?pretty -q -O - | /bin/grep cluster_name" ]
+                "command": [ "/bin/sh", "-c", "timeout -t 5 /usr/bin/wget http://localhost:9200/_cluster/health?pretty -q -O - | /bin/grep cluster_name" ]
               },
               "initialDelaySeconds": 60,
               "timeoutSeconds": 15,

--- a/catalogData/elasticsearch24/6x/k8s/deployment.json
+++ b/catalogData/elasticsearch24/6x/k8s/deployment.json
@@ -52,7 +52,7 @@
             },
             "livenessProbe": {
               "exec": {
-                "command": [ "/bin/sh", "-c", "/usr/bin/wget http://localhost:9200/_cluster/health?pretty -q -O - | /bin/grep cluster_name" ]
+                "command": [ "/bin/sh", "-c", "timeout -t 5 /usr/bin/wget http://localhost:9200/_cluster/health?pretty -q -O - | /bin/grep cluster_name" ]
               },
               "initialDelaySeconds": 60,
               "timeoutSeconds": 15,


### PR DESCRIPTION
For some reason using  busybox's wget did not want to timeout when passing `-T 5` but wrapping the command in timeout worked...

