### PR TITLE
[WIP] Restrict redis srv records to headless.

### DIFF
--- a/custom_images/redis-3.2/k8s-redis-ha-server
+++ b/custom_images/redis-3.2/k8s-redis-ha-server
@@ -39,9 +39,12 @@ run () {
 
   # Headless Service allows newly added Redis server to scan all working servers.
   # This enables it to find if it is the first one.
+  set +e
   local servers
-  servers="$(server_domains "$service_domain")"
+  servers="$(server_domains "$service_domain" | grep "${SERVICE}-[0-9]")"
   readonly servers
+  set -e
+
   local my_host
   my_host="$(hostname -f)"
   readonly my_host
@@ -49,14 +52,11 @@ run () {
   local master_ip=''
   local only_server=true
 
-  local server_count
-  server_count=$(echo "${servers}" | wc -l)
-
   local s
   for s in $servers; do
     # My hostname must be excluded to handle restarts.
     # Skip if single server and service is not headless; SRV record will not match hostname
-    if [ "$s" = "$my_host" ] || [ "${server_count}" -eq 1 ]; then
+    if [ "$s" = "$my_host" ]; then
       continue
     fi
 


### PR DESCRIPTION
Fix checking for `SRV` records for headless services only. For context, the HA plan uses a headless service for the redis servers, but the single-instance plan doesn't, because we need to expose the service to customer apps. This patch fixes the logic to exclude `SRV` records from non-headless services.

Will revert images to 18fgsa after review.