### PR TITLE
Micro Redis

### DIFF
--- a/catalogData/redis32/micro/credentials-mappings.json
+++ b/catalogData/redis32/micro/credentials-mappings.json
@@ -1,0 +1,9 @@
+{
+   "hostname": "$hostname",
+   "password": "$env_REDIS_PASSWORD",
+   "port": "$port_6379",
+   "ports": {
+      "6379/tcp": "$port_6379"
+   },
+   "uri": "redis://:$env_REDIS_PASSWORD@$hostname:$port_6379"
+}

--- a/catalogData/redis32/micro/k8s/account.json
+++ b/catalogData/redis32/micro/k8s/account.json
@@ -1,0 +1,16 @@
+{
+  "kind": "ServiceAccount",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "$idx_and_short_serviceid",
+    "labels": {
+      "org": "$org",
+      "space": "$space",
+      "catalog_service_id": "$catalog_service_id",
+      "catalog_plan_id": "$catalog_plan_id",
+      "service_id": "$service_id",
+      "idx_and_short_serviceid": "$idx_and_short_serviceid",
+      "managed_by": "TAP"
+    }
+  }
+}

--- a/catalogData/redis32/micro/k8s/secret.json
+++ b/catalogData/redis32/micro/k8s/secret.json
@@ -1,0 +1,17 @@
+{
+  "kind": "Secret",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "$short_serviceid-redis-credentials",
+    "labels": {
+      "service_id": "$service_id",
+      "idx_and_short_serviceid": "$idx_and_short_serviceid",
+      "managed_by": "TAP",
+      "collector": "redis"
+    }
+  },
+  "data": {
+    "redis-password": "$base64-$random1"
+  }
+}
+

--- a/catalogData/redis32/micro/k8s/service-server.json
+++ b/catalogData/redis32/micro/k8s/service-server.json
@@ -1,0 +1,29 @@
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "labels": {
+      "org": "$org",
+      "space": "$space",
+      "catalog_service_id": "$catalog_service_id",
+      "catalog_plan_id": "$catalog_plan_id",
+      "service_id": "$service_id",
+      "idx_and_short_serviceid": "$idx_and_short_serviceid",
+      "managed_by": "TAP"
+    },
+    "name": "$idx_and_short_serviceid-server"
+  },
+  "spec": {
+    "type": "NodePort",
+    "ports": [
+      {
+        "name": "redis-server",
+        "port": 6379
+      }
+    ],
+    "selector": {
+      "service_id": "$service_id",
+      "component": "server"
+    }
+  }
+}

--- a/catalogData/redis32/micro/k8s/statefulset-server.json
+++ b/catalogData/redis32/micro/k8s/statefulset-server.json
@@ -1,0 +1,126 @@
+{
+  "apiVersion": "apps/v1beta1",
+  "kind": "StatefulSet",
+  "metadata": {
+    "name": "$idx_and_short_serviceid-server",
+    "labels": {
+      "org": "$org",
+      "space": "$space",
+      "catalog_service_id": "$catalog_service_id",
+      "catalog_plan_id": "$catalog_plan_id",
+      "service_id": "$service_id",
+      "idx_and_short_serviceid": "$idx_and_short_serviceid",
+      "managed_by": "TAP"
+    }
+  },
+  "spec": {
+    "replicas": 1,
+    "selector": {
+      "matchLabels": {
+        "component": "server",
+        "service_id": "$service_id",
+        "idx_and_short_serviceid": "$idx_and_short_serviceid"
+      }
+    },
+    "serviceName": "$idx_and_short_serviceid-server",
+    "template": {
+      "metadata": {
+        "labels": {
+          "component": "server",
+          "service_id": "$service_id",
+          "idx_and_short_serviceid": "$idx_and_short_serviceid",
+          "managed_by": "TAP"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "resources": {
+              "requests": {
+                "memory": "32m"
+              },
+              "limits": {
+                "memory": "64m"
+              }
+            },
+            "command": [
+              "/opt/bin/k8s-redis-ha-server"
+            ],
+            "args": [
+              "/opt/redis.conf"
+            ],
+            "env": [
+              {
+                "name": "SERVICE",
+                "value": "$idx_and_short_serviceid-server"
+              },
+              {
+                "name": "SERVICE_PORT",
+                "value": "redis-server"
+              },
+              {
+                "name": "SENTINEL_HOST",
+                "value": "_"
+              },
+              {
+                "name": "SENTINEL",
+                "value": "_"
+              },
+              {
+                "name": "SENTINEL_PORT",
+                "value": "_"
+              },
+              { "name": "MANAGED_BY", "value":"TAP" },
+              { "name": "REDIS_PASSWORD",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "$short_serviceid-redis-credentials",
+                    "key": "redis-password"
+                  }
+                }
+              }
+            ],
+            "image": "18fgsa/redis:3.2.10",
+            "imagePullPolicy": "IfNotPresent",
+            "name": "redis-server",
+            "ports": [
+              {
+                "containerPort": 6379,
+                "name": "redis-server"
+              }
+            ],
+            "readinessProbe": {
+              "exec": {
+                "command": [
+                  "/opt/bin/k8s-redis-ha-server-ready"
+                ]
+              }
+            },
+            "volumeMounts": [
+              {
+                "mountPath": "/data",
+                "name": "data"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "volumeClaimTemplates": [
+      {
+        "metadata": {
+          "name": "data"
+        },
+        "spec": {
+          "accessModes": ["ReadWriteOnce"],
+          "storageClassName": "$storage_class",
+          "resources": {
+            "requests": {
+              "storage": "1Gi"
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/catalogData/redis32/micro/plan.json
+++ b/catalogData/redis32/micro/plan.json
@@ -1,0 +1,6 @@
+{
+  "id": "eaf5edc4-b85c-4673-b8ed-de5fb93390ac",
+  "name": "micro",
+  "description": "Redis 3.2, persistent storage, 64Mb memory limit",
+  "free": true
+}

--- a/catalogData/redis32/standard-ha/plan.json
+++ b/catalogData/redis32/standard-ha/plan.json
@@ -1,6 +1,6 @@
 {
   "id": "7238138e-722b-11e7-9e57-c30dd7276550",
   "name": "standard-ha",
-  "description": "Redis 3.2 with Redis Sentinel and persistent storage.",
+  "description": "Redis 3.2 with Redis Sentinel, persistent storage, 512Mb memory limit",
   "free": true
 }

--- a/catalogData/redis32/standard/plan.json
+++ b/catalogData/redis32/standard/plan.json
@@ -1,6 +1,6 @@
 {
   "id": "d544b7d7-1f5a-49b3-b96d-690e7450e43b",
   "name": "standard",
-  "description": "Redis 3.2 with persistent storage.",
+  "description": "Redis 3.2, persistent storage, 512Mb memory limit",
   "free": true
 }


### PR DESCRIPTION
At the workshop on Thursday I'd like folks to walk through provisioning a data store and using it with an application. I'd like to use Redis since the code is much simpler for the demo. The `standard` Redis allocates 384Mb and has limits of 512Mb memory and 10Gb disk.   So: how to accommodate ~80 users running `cf create-service redis32` all at once? (edited)


I have a branch for a 32Mb `micro` plan, which should be good for a few hundred thousand small keys (https://redis.io/topics/faq).  First:


Does 32mb request, 64mb limit and 1Gb disk seem reasonable for a `micro` instance