### PR TITLE
Ignore `MANAGED_BY` label.

### DIFF
--- a/k8s/k8sfabricator.go
+++ b/k8s/k8sfabricator.go
@@ -762,7 +762,7 @@ func (k *K8Fabricator) GetAllPodsEnvsByServiceId(creds K8sClusterCredentials, sp
 	if err != nil {
 		return result, err
 	}
-	if len(deployments.Items) == 0 && len(sets.Items) == 0{
+	if len(deployments.Items) == 0 && len(sets.Items) == 0 {
 		return result, fmt.Errorf("No deployments or statefulsets associated with the service: %s", service_id)
 	}
 
@@ -852,15 +852,11 @@ func (k *K8Fabricator) getKubernetesClientWithServiceIdSelector(creds K8sCluster
 
 func getSelectorForServiceIdLabel(serviceId string) (string, error) {
 	selector := labels.NewSelector()
-	managedByReq, err := labels.NewRequirement(managedByLabel, selection.Equals, []string{"TAP"})
-	if err != nil {
-		return "", err
-	}
 	serviceIdReq, err := labels.NewRequirement(serviceIdLabel, selection.Equals, []string{serviceId})
 	if err != nil {
 		return "", err
 	}
-	return selector.Add(*managedByReq, *serviceIdReq).String(), nil
+	return selector.Add(*serviceIdReq).String(), nil
 }
 
 func getSelectorForManagedByLabel() (string, error) {


### PR DESCRIPTION
Persistent volume claims created by stateful sets aren't labeled with the `MANAGED_BY` label, so deleting services that use stateful sets pollute our environment with unused volumes. Drop the label selector on `MANAGED_BY` to resolve.