### PR TITLE
Solve 502 error for users with large requests

### DIFF
--- a/custom_images/nginx/nginx.conf
+++ b/custom_images/nginx/nginx.conf
@@ -17,6 +17,9 @@ http {
     location / {
       proxy_pass http://elasticsearch;
       proxy_redirect off;
+      proxy_buffer_size 64k;
+      proxy_buffers 16 32k;
+      proxy_busy_buffers_size 128k;
     }
   }
 }


### PR DESCRIPTION
Users receive 502 bad gateway with a backend message:
"upstream sent too big header while reading response header from
upstream"

This will allow their requests to work as intended.